### PR TITLE
Add compatibility with Strapi 4.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^5.3.4",
-		"styled-components": "^5.3.6"
+		"styled-components": "^5.3.3"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0 || ^18.0.0",
 		"react-dom": "^17.0.0 || ^18.0.0",
 		"react-router-dom": "^5.3.4",
-		"styled-components": "^5.3.6"
+		"styled-components": "^5.3.3"
 	},
 	"strapi": {
 		"displayName": "Notes",


### PR DESCRIPTION
Allows this package to be installed together with strapi 4.14.5 & Strapi 4.15.0 (no other versions tested). I also didn't test if this package actually requires any of the new features from the downgraded version, but I highly doubt it.